### PR TITLE
time now changes on resume instead of on create

### DIFF
--- a/app/src/main/java/studyBuddy/main_activity/MainActivity.java
+++ b/app/src/main/java/studyBuddy/main_activity/MainActivity.java
@@ -52,19 +52,7 @@ public class MainActivity extends AppCompatActivity
         setContentView(R.layout.home_layout);
         
         timeSelectorIsOpen = false;
-
-        PrimaryColorPicker.setBackgroundFilter(this, findViewById(R.id.session_history_inner));
-
         this.newSessionText = findViewById(R.id.new_session_text);
-        newSessionText.setTextColor(PrimaryColorPicker.getDayColorInt(this));
-
-        // https://stackoverflow.com/questions/22192291/how-to-change-the-status-bar-color-in-android
-        Window window = this.getWindow();
-
-        window.setStatusBarColor(PrimaryColorPicker.getDayColorInt(this));
-
-        PrimaryColorPicker.setBackgroundFilter(this, findViewById(R.id.main_background));
-
         // Load pet
         this.pet = DataManager.load(this, Pet.class);
         if (this.pet == null) {
@@ -119,6 +107,22 @@ public class MainActivity extends AppCompatActivity
         petView = findViewById(R.id.home_pet_view);
         petView.setOnClickListener(this);
         Glide.with(this).asGif().load(this.petAnimation.getCurGif(this)).into(petView);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        newSessionText.setTextColor(PrimaryColorPicker.getDayColorInt(this));
+        PrimaryColorPicker.setBackgroundFilter(this, findViewById(R.id.session_history_inner));
+
+
+        // https://stackoverflow.com/questions/22192291/how-to-change-the-status-bar-color-in-android
+        Window window = this.getWindow();
+
+        window.setStatusBarColor(PrimaryColorPicker.getDayColorInt(this));
+
+        PrimaryColorPicker.setBackgroundFilter(this, findViewById(R.id.main_background));
+
     }
 
     @Override

--- a/app/src/main/java/studyBuddy/session_activity/SessionActivity.java
+++ b/app/src/main/java/studyBuddy/session_activity/SessionActivity.java
@@ -66,17 +66,8 @@ public class SessionActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceBundle) {
         super.onCreate(savedInstanceBundle);
         setContentView(R.layout.session_layout);
-        View background = findViewById(R.id.session_base);
-        background.setBackgroundColor(PrimaryColorPicker.getDayColorInt(this));
 
         View fob = findViewById(R.id.fob);
-        Drawable buttonContents = ((ImageView)fob).getDrawable();
-
-        buttonContents.mutate().setColorFilter(PrimaryColorPicker.getDayColorMatrixFilter(this));
-
-        Window window = this.getWindow();
-
-        window.setStatusBarColor(PrimaryColorPicker.getDayColorInt(this));
 
         session = new Session(new Handler(Looper.getMainLooper()));
         TimelineView timeline = findViewById(R.id.timeLine);
@@ -162,6 +153,17 @@ public class SessionActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         session.resumeSession();
+        View background = findViewById(R.id.session_base);
+        background.setBackgroundColor(PrimaryColorPicker.getDayColorInt(this));
+
+        View fob = findViewById(R.id.fob);
+        Drawable buttonContents = ((ImageView)fob).getDrawable();
+
+        buttonContents.mutate().setColorFilter(PrimaryColorPicker.getDayColorMatrixFilter(this));
+
+        Window window = this.getWindow();
+
+        window.setStatusBarColor(PrimaryColorPicker.getDayColorInt(this));
         // clear notification
     }
 

--- a/app/src/main/java/studyBuddy/session_history_activity/SessionHistoryActivity.java
+++ b/app/src/main/java/studyBuddy/session_history_activity/SessionHistoryActivity.java
@@ -52,10 +52,15 @@ public class SessionHistoryActivity extends AppCompatActivity
 
         homeButton = findViewById(R.id.session_history_home_button_outer);
         homeButton.setOnClickListener(this);
+    }
 
+    @Override
+    protected void onResume() {
+        super.onResume();
         Window window = this.getWindow();
         window.setStatusBarColor(PrimaryColorPicker.getDayColorInt(this));
         PrimaryColorPicker.setBackgroundFilter(this, findViewById(R.id.session_history_home_button_inner));
+
     }
 
     @Override


### PR DESCRIPTION
all activities should now update their color palette when onResume is called, so they'll no longer get "stuck" on an old palette