### PR TITLE
cancels notifications if the session activity is opened via multitask

### DIFF
--- a/app/src/main/java/studyBuddy/session_activity/SessionActivity.java
+++ b/app/src/main/java/studyBuddy/session_activity/SessionActivity.java
@@ -162,6 +162,7 @@ public class SessionActivity extends AppCompatActivity {
     protected void onResume() {
         super.onResume();
         session.resumeSession();
+        cancelOldIntent();
         // clear notification
     }
 
@@ -240,5 +241,16 @@ public class SessionActivity extends AppCompatActivity {
                 SessionRecord[] arr = sessions.toArray(new SessionRecord[0]);
                 DataManager.save(this, arr);
         }
+    }
+
+    private void cancelOldIntent() {
+        Intent broadcast = new Intent(this, SessionBroadcastReceiver.class);
+        AlarmManager mgr = (AlarmManager)getSystemService(ALARM_SERVICE);
+        assert mgr != null;
+        // prevent notification from updating
+        mgr.cancel(PendingIntent.getBroadcast(this, INTENT_ID, broadcast, PendingIntent.FLAG_UPDATE_CURRENT));
+        NotificationManager notifMgr = (NotificationManager)getSystemService(NOTIFICATION_SERVICE);
+        assert notifMgr != null;
+        notifMgr.cancel(INTENT_ID);
     }
 }


### PR DESCRIPTION
quick fix to hide notifications when opening a session back up from multitask view on android